### PR TITLE
세션 캐시 무한루프 문제 해결

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -13,6 +13,7 @@ async function fetchSessionInfo(sessionValue: string) {
         headers: {
             Cookie: `SESSION=${sessionValue}`,
         },
+        cache: "no-store",
     });
 
     if (!res.ok) {


### PR DESCRIPTION
next.js의 동작에 의한 에러.

메인 페이지에 있는 fetch 함수 결과값이 html -> 캐시 처리 시도 -> 2mb 이상은 캐쉬할 수 없는 에러 발생 -> 메인 페이지 이동 -> 메인 페이지에 있는 fetch 함수 실행 -> 캐시 처리 -> ...

해결하기 위해 적절히 캐시 전략 수립